### PR TITLE
Exclude test directory during install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,9 @@ tests_require =
   scspell3k>=2.2
 zip_safe = true
 
+[options.packages.find]
+exclude = test
+
 [tool:pytest]
 filterwarnings =
     error


### PR DESCRIPTION
Currently, because `packages = find:` is used and the `test` folder also contains a `__init__.py`, the `test` folder is also installed. This is unintended and leads to problems with some other packages. Adding the `exclude` option solves the problem.