### PR TITLE
Ignore a deprecation warning in scspell in Python 3.9+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ exclude = test
 filterwarnings =
     error
     ignore::DeprecationWarning:scantree.*:
+    ignore::PendingDeprecationWarning:scspell:
 junit_suite_name = colcon-clean
 
 [options.entry_points]


### PR DESCRIPTION
Because of `filterwarnings = error`, this deprecation is becoming an error for Python 3.9 and newer under certain circumstances:
```
PendingDeprecationWarning: lib2to3 package is deprecated and may not be able to parse Python 3.10+
```