### PR TITLE
Register colcon-clean extension points

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,9 @@ colcon_clean.base_handler =
 colcon_clean.subverb =
     workspace = colcon_clean.subverb.workspace:WorkspaceCleanSubverb
     packages = colcon_clean.subverb.packages:PackagesCleanSubverb
+colcon_core.extension_point =
+    colcon_clean.base_handler = colcon_clean.base_handler:BaseHandlerExtensionPoint
+    colcon_clean.subverb = colcon_clean.subverb:CleanSubverbExtensionPoint
 colcon_core.verb =
     clean = colcon_clean.verb.clean:CleanVerb
 


### PR DESCRIPTION
Registering the extension points in this way will make them visible when running `colcon extesion-points`.