### PR TITLE
Specify target module when analyzing coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,3 +74,4 @@ import-order-style = google
 
 [coverage:run]
 branch = True
+source = colcon_clean


### PR DESCRIPTION
This seems to help avoid coverage for other modules unexpectedly bleeding into the results.