### PR TITLE
Improve --base-select and add --base-ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Additional arguments supported by all subverbs provide the option to select whic
 
 - `--base-select`
   - Select base names to clean in workspace (default: [build, install, log, test_result])
+- `--base-ignore`
+  - Ignore base names to clean in workspace (default: [])
 - `--build-base`
   - The base path for all build directories (default: build)
 - `--install-base`

--- a/colcon_clean/base_handler/__init__.py
+++ b/colcon_clean/base_handler/__init__.py
@@ -67,13 +67,14 @@ def add_base_handler_arguments(parser):
     """
     group = parser.add_argument_group(title='Base handler arguments')
     extensions = get_base_handler_extensions()
+    extension_keys = sorted(extensions.keys())
 
-    default_base_select = sorted(extensions.keys())
     group.add_argument(
         '--base-select', nargs='*', metavar='BASE_NAME',
-        default=default_base_select,
+        choices=extension_keys,
+        default=extension_keys,
         help='Select base names to clean in workspace '
-             '(default: {default_base_select})'.format_map(locals()))
+             '(default: {extension_keys})'.format_map(locals()))
 
     for key in sorted(extensions.keys()):
         extension = extensions[key]

--- a/colcon_clean/base_handler/__init__.py
+++ b/colcon_clean/base_handler/__init__.py
@@ -68,11 +68,12 @@ def add_base_handler_arguments(parser):
     group = parser.add_argument_group(title='Base handler arguments')
     extensions = get_base_handler_extensions()
 
+    default_base_select = sorted(extensions.keys())
     group.add_argument(
         '--base-select', nargs='*', metavar='BASE_NAME',
-        default=sorted(extensions.keys()),
+        default=default_base_select,
         help='Select base names to clean in workspace '
-             '(default: [build, install, log, test_result])')
+             '(default: {default_base_select})'.format_map(locals()))
 
     for key in sorted(extensions.keys()):
         extension = extensions[key]

--- a/colcon_clean/base_handler/__init__.py
+++ b/colcon_clean/base_handler/__init__.py
@@ -76,6 +76,13 @@ def add_base_handler_arguments(parser):
         help='Select base names to clean in workspace '
              '(default: {extension_keys})'.format_map(locals()))
 
+    group.add_argument(
+        '--base-ignore', nargs='*', metavar='BASE_NAME',
+        choices=extension_keys,
+        default=[],
+        help='Ignore base names to clean in workspace '
+             '(default: [])')
+
     for key in sorted(extensions.keys()):
         extension = extensions[key]
         extension.add_arguments(parser=group)

--- a/colcon_clean/subverb/packages.py
+++ b/colcon_clean/subverb/packages.py
@@ -52,23 +52,18 @@ class PackagesCleanSubverb(CleanSubverbExtensionPoint):
                     "Ignoring base handler for selection '{base_name}'"
                     .format_map(locals()))
                 continue
-            if base_name in base_handler_extensions:
-                base_handler_extension = base_handler_extensions[base_name]
-                for decorator in decorators:
-                    if not decorator.selected:
-                        continue
-                    pkg = decorator.descriptor
-                    package_paths = \
-                        base_handler_extension.get_package_paths(
-                            args=args, pkg=pkg)
-                    for package_path in package_paths:
-                        package_path = Path(package_path).absolute()
-                        base_paths.update(
-                            scan_directory(package_path, recursion_filter))
-            else:
-                logger.warning(
-                    "No base handler for selection '{base_name}'"
-                    .format_map(locals()))
+            base_handler_extension = base_handler_extensions[base_name]
+            for decorator in decorators:
+                if not decorator.selected:
+                    continue
+                pkg = decorator.descriptor
+                package_paths = \
+                    base_handler_extension.get_package_paths(
+                        args=args, pkg=pkg)
+                for package_path in package_paths:
+                    package_path = Path(package_path).absolute()
+                    base_paths.update(
+                        scan_directory(package_path, recursion_filter))
 
         clean_paths(
             paths=base_paths,

--- a/colcon_clean/subverb/packages.py
+++ b/colcon_clean/subverb/packages.py
@@ -47,6 +47,11 @@ class PackagesCleanSubverb(CleanSubverbExtensionPoint):
         recursion_filter = get_recursion_filter(args)
 
         for base_name in args.base_select:
+            if base_name in args.base_ignore:
+                logger.info(
+                    "Ignoring base handler for selection '{base_name}'"
+                    .format_map(locals()))
+                continue
             if base_name in base_handler_extensions:
                 base_handler_extension = base_handler_extensions[base_name]
                 for decorator in decorators:

--- a/colcon_clean/subverb/workspace.py
+++ b/colcon_clean/subverb/workspace.py
@@ -42,6 +42,11 @@ class WorkspaceCleanSubverb(CleanSubverbExtensionPoint):
         recursion_filter = get_recursion_filter(args)
 
         for base_name in args.base_select:
+            if base_name in args.base_ignore:
+                logger.info(
+                    "Ignoring base handler for selection '{base_name}'"
+                    .format_map(locals()))
+                continue
             if base_name in base_handler_extensions:
                 base_handler_extension = base_handler_extensions[base_name]
                 workspace_paths = \

--- a/colcon_clean/subverb/workspace.py
+++ b/colcon_clean/subverb/workspace.py
@@ -47,18 +47,13 @@ class WorkspaceCleanSubverb(CleanSubverbExtensionPoint):
                     "Ignoring base handler for selection '{base_name}'"
                     .format_map(locals()))
                 continue
-            if base_name in base_handler_extensions:
-                base_handler_extension = base_handler_extensions[base_name]
-                workspace_paths = \
-                    base_handler_extension.get_workspace_paths(args=args)
-                for workspace_path in workspace_paths:
-                    workspace_path = Path(workspace_path).absolute()
-                    base_paths.update(
-                        scan_directory(workspace_path, recursion_filter))
-            else:
-                logger.warning(
-                    "No base handler for selection '{base_name}'"
-                    .format_map(locals()))
+            base_handler_extension = base_handler_extensions[base_name]
+            workspace_paths = \
+                base_handler_extension.get_workspace_paths(args=args)
+            for workspace_path in workspace_paths:
+                workspace_path = Path(workspace_path).absolute()
+                base_paths.update(
+                    scan_directory(workspace_path, recursion_filter))
 
         clean_paths(
             paths=base_paths,

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,4 +1,5 @@
 apache
+argparse
 blocklist
 builtins
 chdir

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -68,6 +68,16 @@ def test_main(monkeypatch):
         monkeypatch.setattr('builtins.input', lambda _: 'n')
         main(argv=argv + ['clean', 'workspace'])  # noqa
 
+        # Ignore one workspace base paths explicitly
+        main(argv=argv + ['clean', 'workspace', \
+            '--base-ignore', \
+                'log'])  # noqa
+
+        # Ignore one workspace base paths explicitly
+        main(argv=argv + ['clean', 'packages', \
+            '--base-ignore', \
+                'log'])  # noqa
+
         # Clean workspace base paths when prompted by user input
         monkeypatch.setattr('builtins.input', lambda _: 'y')
         main(argv=argv + ['clean', 'workspace'])  # noqa

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import shutil
 from tempfile import mkdtemp
 
+import argparse
 from colcon_core.command import main
+import pytest
 
 
 def test_main(monkeypatch):
@@ -82,15 +84,17 @@ def test_main(monkeypatch):
         monkeypatch.setattr('builtins.input', lambda _: 'y')
         main(argv=argv + ['clean', 'workspace'])  # noqa
 
-        # Try cleaning packages with invalid base handler selection
-        main(argv=argv + ['clean', 'packages', '--yes', \
-            '--base-select', \
-                'foo'])  # noqa
+        with pytest.raises(argparse.ArgumentError):
+            # Try cleaning packages with invalid base handler selection
+            main(argv=argv + ['clean', 'packages', '--yes', \
+                '--base-select', \
+                    'foo'])  # noqa
 
-        # Try cleaning workspace with invalid base handler selection
-        main(argv=argv + ['clean', 'workspace', '--yes', \
-            '--base-select', \
-                'foo'])  # noqa
+        with pytest.raises(argparse.ArgumentError):
+            # Try cleaning workspace with invalid base handler selection
+            main(argv=argv + ['clean', 'workspace', '--yes', \
+                '--base-select', \
+                    'foo'])  # noqa
 
         print('ws_base: ', ws_base)
     finally:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -67,7 +67,7 @@ def test_main(monkeypatch):
         main(argv=argv + ['build'])
 
         # Don't clean workspace base paths when prompted by user input
-        monkeypatch.setattr('builtins.input', lambda _: 'n')
+        monkeypatch.setattr('builtins.input', lambda: 'n')
         main(argv=argv + ['clean', 'workspace'])  # noqa
 
         # Ignore one workspace base paths explicitly
@@ -81,7 +81,7 @@ def test_main(monkeypatch):
                 'log'])  # noqa
 
         # Clean workspace base paths when prompted by user input
-        monkeypatch.setattr('builtins.input', lambda _: 'y')
+        monkeypatch.setattr('builtins.input', lambda: 'y')
         main(argv=argv + ['clean', 'workspace'])  # noqa
 
         with pytest.raises(argparse.ArgumentError):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -12,6 +12,13 @@ from colcon_core.command import main
 import pytest
 
 
+def _raising_error(self, message):
+    raise sys.exc_info()[1]
+
+
+argparse.ArgumentParser.error = _raising_error
+
+
 def test_main(monkeypatch):
     ws_base = Path(mkdtemp(prefix='test_colcon_'))
     resources_base = Path('test', 'resources').absolute()
@@ -85,43 +92,21 @@ def test_main(monkeypatch):
         monkeypatch.setattr('builtins.input', lambda: 'y')
         main(argv=argv + ['clean', 'workspace'])  # noqa
 
+        with pytest.raises(argparse.ArgumentError):
+            # Try cleaning packages with invalid base handler selection
+            main(argv=argv + ['clean', 'packages', \
+                '--base-select', \
+                    'foo'])  # noqa
+
+        with pytest.raises(argparse.ArgumentError):
+            # Try cleaning workspace with invalid base handler selection
+            main(argv=argv + ['clean', 'workspace', \
+                '--base-select', \
+                    'bar'])  # noqa
+
         print('ws_base: ', ws_base)
     finally:
         # the logging subsystem might still have file handles pending
         # therefore only try to delete the temporary directory
         # shutil.rmtree(ws_base, ignore_errors=True)
         pass
-
-
-class _RaisingArgumentParser(argparse.ArgumentParser):
-
-    def error(self, message):
-        raise sys.exc_info()[1]
-
-    def test_suppress_argument_error(self, monkeypatch):
-        ws_base = Path(mkdtemp(prefix='test_colcon_'))
-        resources_base = Path('test', 'resources').absolute()
-        shutil.copytree(resources_base / 'test_src', ws_base / 'src')
-
-        os.chdir(ws_base)
-        argv = []
-        os.environ['COLCON_EXTENSION_BLOCKLIST'] = (
-            'colcon_core.event_handler.desktop_notification:' +
-            os.environ.get('COLCON_EXTENSION_BLOCKLIST', ''))
-
-        main(argv=argv + ['build'])
-
-        # Clean workspace base paths when prompted by user input
-        monkeypatch.setattr('builtins.input', lambda: 'y')
-
-        with pytest.raises(argparse.ArgumentError):
-            # Try cleaning packages with invalid base handler selection
-            main(argv=argv + ['clean', 'packages', '--yes', \
-                '--base-select', \
-                    'foo'])  # noqa
-
-        with pytest.raises(argparse.ArgumentError):
-            # Try cleaning workspace with invalid base handler selection
-            main(argv=argv + ['clean', 'workspace', '--yes', \
-                '--base-select', \
-                    'bar'])  # noqa


### PR DESCRIPTION
Fix help message when printing default for --base-select
To ensure all available base select options are displayed, including any external base handler extensions.

And add --base-ignore to ignore (default) base paths otherwise selected.

This allows uses to do things like cleaning all but a few ignored base paths, regardless of how many other base path and extension may be present.