### PR TITLE
Update filterwarnings with new lib2to3 deprecation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ filterwarnings =
     ignore::DeprecationWarning:colcon_defaults:
     ignore::DeprecationWarning:flake8:
     ignore::DeprecationWarning:scantree.*:
-    ignore::PendingDeprecationWarning:scspell:
+    ignore:lib2to3 package is deprecated::scspell
     ignore::pytest.PytestUnraisableExceptionWarning
 junit_suite_name = colcon-clean
 


### PR DESCRIPTION
While this was originally a PendingDeprecationWarning, it is now a DeprecationWarning and as such the filter needs to be updated.

I made it look like the entry used in `colcon-core`, which didn't need to be updated after the upstream class changed. If you'd instead like to update the class to match the pattern used in this package, I'm happy to change it.