### PR TITLE
Set long_description_content_type in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
 license = Apache License, Version 2.0
 description = Extension for colcon to clean package workspaces.
 long_description = file: README.md
+long_description_content_type = text/markdown
 keywords = colcon
 
 [options]


### PR DESCRIPTION
The default is assumed to be rst, and PyPI is unhappy that it can't render it as such. Explicitly stating that the content is markdown resolves the issue.