### PR TITLE
Add publish-python.yaml

### DIFF
--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -1,0 +1,12 @@
+artifacts:
+  - type: wheel
+    uploads:
+      - type: pypi
+  - type: stdeb
+    uploads:
+      - type: packagecloud
+        config:
+          repository: dirk-thomas/colcon
+          distributions:
+            - ubuntu:jammy
+            - debian:bullseye


### PR DESCRIPTION
This file is used by https://github.com/dirk-thomas/publish-python to publish the package to PyPI and Package Cloud.