### PR TITLE
Fix deprecations

### DIFF
--- a/colcon_clean/base_handler/__init__.py
+++ b/colcon_clean/base_handler/__init__.py
@@ -74,7 +74,7 @@ def add_base_handler_arguments(parser):
         choices=extension_keys,
         default=extension_keys,
         help='Select base names to clean in workspace '
-             '(default: {extension_keys})'.format_map(locals()))
+             f'(default: {extension_keys})')
 
     group.add_argument(
         '--base-ignore', nargs='*', metavar='BASE_NAME',

--- a/colcon_clean/base_handler/build.py
+++ b/colcon_clean/base_handler/build.py
@@ -22,7 +22,7 @@ class BuildBaseHandler(BaseHandlerExtensionPoint):
             '--build-base',
             default=self.base_path,
             help='The base path for all build directories '
-                 '(default: {self.base_path})'.format_map(locals()))
+                 f'(default: {self.base_path})')
 
     def get_workspace_paths(self, *, args):  # noqa: D102
         return [args.build_base]

--- a/colcon_clean/base_handler/install.py
+++ b/colcon_clean/base_handler/install.py
@@ -22,7 +22,7 @@ class InstallBaseHandler(BaseHandlerExtensionPoint):
             '--install-base',
             default=self.base_path,
             help='The base path for all install directories '
-                 '(default: {self.base_path})'.format_map(locals()))
+                 f'(default: {self.base_path})')
 
     def get_workspace_paths(self, *, args):  # noqa: D102
         return [args.install_base]

--- a/colcon_clean/base_handler/log.py
+++ b/colcon_clean/base_handler/log.py
@@ -20,7 +20,7 @@ class LogBaseHandler(BaseHandlerExtensionPoint):
             '--log-base',
             default=self.base_path,
             help='The base path for all log directories '
-                 '(default: {self.base_path})'.format_map(locals()))
+                 f'(default: {self.base_path})')
 
     def get_workspace_paths(self, *, args):  # noqa: D102
         return [args.log_base]

--- a/colcon_clean/base_handler/test_result.py
+++ b/colcon_clean/base_handler/test_result.py
@@ -24,7 +24,7 @@ class TestResultBaseHandler(BaseHandlerExtensionPoint):
             '--test-result-base',
             default=self.base_path,
             help='The base path for all test_result directories '
-                 '(default: {self.base_path})'.format_map(locals()))
+                 f'(default: {self.base_path})')
 
     def get_workspace_paths(self, *, args):  # noqa: D102
         return [args.test_result_base]

--- a/colcon_clean/subverb/__init__.py
+++ b/colcon_clean/subverb/__init__.py
@@ -244,17 +244,14 @@ def clean_paths(paths, confirmed=False):
 
 def _onexc(func, path, excinfo):  # pragma: no cover
     if isinstance(excinfo, (PermissionError, OSError)):  # pragma: no branch
-        logger.warning(
-            "Skipping path: '{path}'".format_map(locals()))
-        logger.info(
-            "Skipping info: '{excinfo}'".format_map(locals()))
+        logger.warning(f"Skipping path: '{path}'")
+        logger.info(f"Skipping info: '{excinfo}'")
         return
     raise
 
 
 def _clean_path(path):
-    logger.info(
-        "Cleaning path: '{path}'".format_map(locals()))
+    logger.info(f"Cleaning path: '{path}'")
     if path.is_dir():
         shutil.rmtree(path, onexc=_onexc)
     else:

--- a/colcon_clean/subverb/__init__.py
+++ b/colcon_clean/subverb/__init__.py
@@ -242,12 +242,12 @@ def clean_paths(paths, confirmed=False):
             _clean_path(path)
 
 
-def _onerror(func, path, excinfo):  # pragma: no cover
-    if excinfo[0] in (OSError, PermissionError):  # pragma: no branch
+def _onexc(func, path, excinfo):  # pragma: no cover
+    if isinstance(excinfo, (PermissionError, OSError)):  # pragma: no branch
         logger.warning(
             "Skipping path: '{path}'".format_map(locals()))
         logger.info(
-            "Skipping info: '{excinfo[1]}'".format_map(locals()))
+            "Skipping info: '{excinfo}'".format_map(locals()))
         return
     raise
 
@@ -256,6 +256,6 @@ def _clean_path(path):
     logger.info(
         "Cleaning path: '{path}'".format_map(locals()))
     if path.is_dir():
-        shutil.rmtree(path, onerror=_onerror)
+        shutil.rmtree(path, onexc=_onexc)
     else:
         path.unlink()

--- a/colcon_clean/subverb/packages.py
+++ b/colcon_clean/subverb/packages.py
@@ -48,9 +48,7 @@ class PackagesCleanSubverb(CleanSubverbExtensionPoint):
 
         for base_name in args.base_select:
             if base_name in args.base_ignore:
-                logger.info(
-                    "Ignoring base handler for selection '{base_name}'"
-                    .format_map(locals()))
+                logger.info(f"Ignoring base handler for selection '{base_name}'")
                 continue
             base_handler_extension = base_handler_extensions[base_name]
             for decorator in decorators:

--- a/colcon_clean/subverb/workspace.py
+++ b/colcon_clean/subverb/workspace.py
@@ -43,9 +43,7 @@ class WorkspaceCleanSubverb(CleanSubverbExtensionPoint):
 
         for base_name in args.base_select:
             if base_name in args.base_ignore:
-                logger.info(
-                    "Ignoring base handler for selection '{base_name}'"
-                    .format_map(locals()))
+                logger.info(f"Ignoring base handler for selection '{base_name}'")
                 continue
             base_handler_extension = base_handler_extensions[base_name]
             workspace_paths = \

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -18,6 +18,7 @@ mkdtemp
 monkeypatch
 nargs
 noqa
+onexc
 pathlib
 plugin
 pytest

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -43,9 +43,6 @@ def test_flake8():
         if report_tests.total_errors:
             report_tests._application.formatter.show_statistics(
                 report_tests._stats)
-        print(
-            'flake8 reported {total_errors} errors'
-            .format_map(locals()), file=sys.stderr)
+        print(f'flake8 reported {total_errors} errors', file=sys.stderr)
 
-    assert not total_errors, \
-        'flake8 reported {total_errors} errors'.format_map(locals())
+    assert not total_errors, f'flake8 reported {total_errors} errors'

--- a/test/test_spell_check.py
+++ b/test/test_spell_check.py
@@ -36,14 +36,14 @@ def test_spell_check(known_words):
 
     unknown_word_count = len(report.unknown_words)
     assert unknown_word_count == 0, \
-        'Found {unknown_word_count} unknown words: '.format_map(locals()) + \
+        f'Found {unknown_word_count} unknown words: ' + \
         ', '.join(sorted(report.unknown_words))
 
     unused_known_words = set(known_words) - report.found_known_words
     unused_known_word_count = len(unused_known_words)
     assert unused_known_word_count == 0, \
-        '{unused_known_word_count} words in the word list are not used: ' \
-        .format_map(locals()) + ', '.join(sorted(unused_known_words))
+        f'{unused_known_word_count} words in the word list are not used: ' + \
+        ', '.join(sorted(unused_known_words))
 
 
 def test_spell_check_word_list_order(known_words):


### PR DESCRIPTION
and update string formatting.

> The deprecated onerror is similar to onexc, except that the third parameter it receives is the tuple returned from `sys.exc_info()`.

- https://docs.python.org/3/library/shutil.html#shutil.rmtree