### PR TITLE
Relax mandatory need for relative base paths

### DIFF
--- a/colcon_clean/subverb/__init__.py
+++ b/colcon_clean/subverb/__init__.py
@@ -232,14 +232,14 @@ def clean_paths(paths, confirmed=False):
     cwd_path = Path.cwd()
     if not confirmed:
         print('Paths:')
-        for path in sorted(paths):
-            path = os.path.relpath(path, cwd_path)
+        relpaths = (os.path.relpath(path, cwd_path) for path in paths)
+        for path in sorted(relpaths):
             print('    ', path)
         question = 'Clean the above paths?'
         confirmed = query_yes_no(question)
 
     if confirmed:
-        for path in paths:
+        for path in sorted(paths):
             _clean_path(path)
 
 

--- a/colcon_clean/subverb/__init__.py
+++ b/colcon_clean/subverb/__init__.py
@@ -2,6 +2,7 @@
 # Copyright 2021 Ruffin White
 # Licensed under the Apache License, Version 2.0
 
+import os
 from pathlib import Path
 import shutil
 
@@ -232,7 +233,7 @@ def clean_paths(paths, confirmed=False):
     if not confirmed:
         print('Paths:')
         for path in sorted(paths):
-            path = path.relative_to(cwd_path)
+            path = os.path.relpath(path, cwd_path)
             print('    ', path)
         question = 'Clean the above paths?'
         confirmed = query_yes_no(question)

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -21,6 +21,8 @@ noqa
 pathlib
 plugin
 pytest
+relpath
+relpaths
 rmtree
 rtype
 scantree


### PR DESCRIPTION
by using `os.path.relpath()` instead of `path.relative_to()`, allowing for absolute paths that are not sub paths to CWD.

Fixes https://github.com/colcon/colcon-clean/issues/37