### PR TITLE
Update deb platforms

### DIFF
--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -9,4 +9,6 @@ artifacts:
           repository: dirk-thomas/colcon
           distributions:
             - ubuntu:jammy
+            - ubuntu:noble
             - debian:bookworm
+            - debian:trixie

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-clean]
 No-Python2:
 Depends3: python3-colcon-core (>= 0.5.2), python3-scantree
-Suite: jammy bookworm
+Suite: jammy noble bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
Added:
* Ubuntu Noble (24.04 LTS pre-release)
* Debian Trixie (testing)

Dropped:
* None

Retained:
* Debian Bookworm (stable)
* Ubuntu Jammy (22.04 LTS)