### PR TITLE
Restore support for Python < 3.12

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -37,6 +37,7 @@ subparsers
 subverb
 tempfile
 thomas
+todo
 unittest
 wildcard
 workspaces


### PR DESCRIPTION
According to the docs, onexc was introduced in 3.12, so this will need to stay around for quite a while longer.

Fixes #40