### PR TITLE
Pin scantree to < 0.0.2a0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ keywords = colcon
 python_requires = >=3.6
 install_requires =
   colcon-core>=0.5.2
-  scantree
+  scantree<0.0.2a0
   scandir;platform_system=='Windows'
 packages = find:
 zip_safe = true


### PR DESCRIPTION
This version regresses support for Windows.

Upstream fix: andhus/scantree#5

https://pypi.org/project/scantree/#history
